### PR TITLE
VS2015 and QT 5.6.0 support

### DIFF
--- a/BuildGNURadio.cmake
+++ b/BuildGNURadio.cmake
@@ -13,7 +13,7 @@ set(GNURADIO_BRANCH v3.7.8.1)
 set(GROSMOSDR_BRANCH master)
 
 #Use Python27 for Cheetah templates support
-set(PYTHON2_EXECUTABLE C:/Python27/python.exe)
+set(PYTHON2_EXECUTABLE c:/python27/python.exe)
 
 ############################################################
 ## Build Volk
@@ -26,6 +26,7 @@ ExternalProject_Add(volk
         ${PROJECT_SOURCE_DIR}/patches/volk_cpuid_count_for_msvc.diff
         ${PROJECT_SOURCE_DIR}/patches/volk_config_log2_vc11.diff
         ${PROJECT_SOURCE_DIR}/patches/volk_skip_profile_app_vc11.diff
+		${PROJECT_SOURCE_DIR}/patches/volk_fix_msvc14.diff
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS
         -Wno-dev
@@ -63,6 +64,7 @@ ExternalProject_Add(GNURadio
         ${PROJECT_SOURCE_DIR}/patches/gnuradio_fix_filter_truncation.diff
         ${PROJECT_SOURCE_DIR}/patches/gnuradio_portaudio_add_io_h.diff
         ${PROJECT_SOURCE_DIR}/patches/gnuradio_udp_source_linger.diff
+		${PROJECT_SOURCE_DIR}/patches/gnuradio_fix_msvc14.diff
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS
         -Wno-dev

--- a/BuildGNURadio.cmake
+++ b/BuildGNURadio.cmake
@@ -13,7 +13,7 @@ set(GNURADIO_BRANCH v3.7.8.1)
 set(GROSMOSDR_BRANCH master)
 
 #Use Python27 for Cheetah templates support
-set(PYTHON2_EXECUTABLE c:/python27/python.exe)
+set(PYTHON2_EXECUTABLE c:/Python27/python.exe)
 
 ############################################################
 ## Build Volk

--- a/BuildGNURadio.cmake
+++ b/BuildGNURadio.cmake
@@ -13,7 +13,7 @@ set(GNURADIO_BRANCH v3.7.8.1)
 set(GROSMOSDR_BRANCH master)
 
 #Use Python27 for Cheetah templates support
-set(PYTHON2_EXECUTABLE c:/Python27/python.exe)
+set(PYTHON2_EXECUTABLE C:/Python27/python.exe)
 
 ############################################################
 ## Build Volk

--- a/BuildHwDrivers.cmake
+++ b/BuildHwDrivers.cmake
@@ -101,6 +101,8 @@ message(STATUS "Configuring bladeRF - ${BLADERF_BRANCH}")
 ExternalProject_Add(bladeRF
     GIT_REPOSITORY https://github.com/Nuand/bladeRF.git
     GIT_TAG ${BLADERF_BRANCH}
+	PATCH_COMMAND ${GIT_PATCH_HELPER} --git ${GIT_EXECUTABLE}
+        ${PROJECT_SOURCE_DIR}/patches/bladerf_msvc14_fix.diff
     CONFIGURE_COMMAND
         "${CMAKE_COMMAND}" <SOURCE_DIR>/host
         -G ${CMAKE_GENERATOR}

--- a/BuildPothos.cmake
+++ b/BuildPothos.cmake
@@ -14,7 +14,7 @@ set(POCO_BRANCH poco-1.6.2)
 set(SPUCE_BRANCH 0.4.3)
 set(MUPARSERX_BRANCH master)
 set(POTHOS_SERIALIZATION_BRANCH pothos-serialization-0.2.0)
-set(POTHOS_BRANCH master)
+set(POTHOS_BRANCH pothos-0.3.1)
 
 ############################################################
 ## Build Poco

--- a/BuildPothos.cmake
+++ b/BuildPothos.cmake
@@ -47,6 +47,7 @@ ExternalProject_Add(Spuce
     GIT_TAG ${SPUCE_BRANCH}
     PATCH_COMMAND ${GIT_PATCH_HELPER} --git ${GIT_EXECUTABLE}
         ${PROJECT_SOURCE_DIR}/patches/spuce_vc11_fixes.diff
+		${PROJECT_SOURCE_DIR}/patches/spuce_fix_msvc14.diff
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
     CMAKE_ARGS
         -Wno-dev

--- a/BuildSoapySDR.cmake
+++ b/BuildSoapySDR.cmake
@@ -36,10 +36,10 @@ ExternalProject_Add(SoapySDR
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
         -DSOAPY_SDR_EXTVER=${EXTRA_VERSION_INFO}
-        -DPYTHON_EXECUTABLE=c:/python27/python.exe
-		-DPYTHON_LIBRARY=c:/python27/libs/python27.lib
-        -DPYTHON3_EXECUTABLE=c:/python34/python.exe
-        -DPYTHON3_LIBRARY=c:/python34/libs/python34.lib
+        -DPYTHON_EXECUTABLE=c:/Python27/python.exe
+		-DPYTHON_LIBRARY=c:/Python27/libs/python27.lib
+        -DPYTHON3_EXECUTABLE=c:/Python34/python.exe
+        -DPYTHON3_LIBRARY=c:/Python34/libs/python34.lib
         -DSWIG_EXECUTABLE=${SWIG_EXECUTABLE}
         -DSWIG_DIR=${SWIG_DIR}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}

--- a/BuildSoapySDR.cmake
+++ b/BuildSoapySDR.cmake
@@ -36,9 +36,10 @@ ExternalProject_Add(SoapySDR
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
         -DSOAPY_SDR_EXTVER=${EXTRA_VERSION_INFO}
-        -DPYTHON_EXECUTABLE=C:/Python27/python.exe
-        -DPYTHON3_EXECUTABLE=C:/Python34/python.exe
-        -DPYTHON3_LIBRARY=C:/Python34/libs/python34.lib
+        -DPYTHON_EXECUTABLE=c:/python27/python.exe
+		-DPYTHON_LIBRARY=c:/python27/libs/python27.lib
+        -DPYTHON3_EXECUTABLE=c:/python34/python.exe
+        -DPYTHON3_LIBRARY=c:/python34/libs/python34.lib
         -DSWIG_EXECUTABLE=${SWIG_EXECUTABLE}
         -DSWIG_DIR=${SWIG_DIR}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}

--- a/BuildSoapySDR.cmake
+++ b/BuildSoapySDR.cmake
@@ -36,10 +36,10 @@ ExternalProject_Add(SoapySDR
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
         -DSOAPY_SDR_EXTVER=${EXTRA_VERSION_INFO}
-        -DPYTHON_EXECUTABLE=c:/Python27/python.exe
-		-DPYTHON_LIBRARY=c:/Python27/libs/python27.lib
-        -DPYTHON3_EXECUTABLE=c:/Python34/python.exe
-        -DPYTHON3_LIBRARY=c:/Python34/libs/python34.lib
+        -DPYTHON_EXECUTABLE=C:/Python27/python.exe
+		-DPYTHON_LIBRARY=C:/Python27/libs/python27.lib
+        -DPYTHON3_EXECUTABLE=C:/Python34/python.exe
+        -DPYTHON3_LIBRARY=C:/Python34/libs/python34.lib
         -DSWIG_EXECUTABLE=${SWIG_EXECUTABLE}
         -DSWIG_DIR=${SWIG_DIR}
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${CMAKE_BUILD_TYPE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_compile_options(/MP) #multi-core build
 ########################################################################
 # Install helper scripts
 ########################################################################
-set(GIT_PATCH_HELPER c:/python34/python.exe ${PROJECT_SOURCE_DIR}/Scripts/GitPatchHelper.py)
+set(GIT_PATCH_HELPER C:/python34/python.exe ${PROJECT_SOURCE_DIR}/Scripts/GitPatchHelper.py)
 
 install(DIRECTORY Scripts DESTINATION ".")
 install(DIRECTORY patches DESTINATION ".")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ add_compile_options(/MP) #multi-core build
 ########################################################################
 # Install helper scripts
 ########################################################################
-set(GIT_PATCH_HELPER C:/Python34/python.exe ${PROJECT_SOURCE_DIR}/Scripts/GitPatchHelper.py)
+set(GIT_PATCH_HELPER c:/python34/python.exe ${PROJECT_SOURCE_DIR}/Scripts/GitPatchHelper.py)
 
 install(DIRECTORY Scripts DESTINATION ".")
 install(DIRECTORY patches DESTINATION ".")

--- a/InstallPrebuilt.cmake
+++ b/InstallPrebuilt.cmake
@@ -68,7 +68,7 @@ install(FILES
 ############################################################
 ## Pthreads (prebuilt)
 ############################################################
-set(THREADS_PTHREADS_ROOT C:/pthreads)
+set(THREADS_PTHREADS_ROOT C:/local/pthreads-w32-2.9.1)
 set(THREADS_PTHREADS_INCLUDE_DIR ${THREADS_PTHREADS_ROOT}/include)
 set(THREADS_PTHREADS_WIN32_LIBRARY ${THREADS_PTHREADS_ROOT}/lib/x64/pthreadVC2.lib)
 
@@ -85,7 +85,7 @@ install(FILES
 ############################################################
 ## PortAudio dependency (prebuilt)
 ############################################################
-set(PORTAUDIO_ROOT C:/portaudio-r1891-build)
+set(PORTAUDIO_ROOT C:/local/portaudio-r1891-build)
 set(PORTAUDIO_INCLUDE_DIR ${PORTAUDIO_ROOT}/include)
 set(PORTAUDIO_LIBRARY ${PORTAUDIO_ROOT}/lib/x64/Release/portaudio_x64.lib)
 
@@ -96,6 +96,10 @@ install(FILES "${PORTAUDIO_ROOT}/lib/x64/Release/portaudio_x64.dll" DESTINATION 
 ############################################################
 ## Qt5 (prebuilt)
 ############################################################
+if (MSVC14)
+    set(QT5_DLL_ROOT C:/Qt/Qt5.6.0/5.6/msvc2015_64)
+endif ()
+
 if (MSVC12)
     set(QT5_DLL_ROOT C:/Qt/Qt5.5.1/5.5/msvc2013_64)
 endif ()
@@ -127,7 +131,7 @@ install(FILES "${QT5_DLL_ROOT}/plugins/platforms/qwindows.dll" DESTINATION bin/p
 ############################################################
 ## LibUSB dependency (prebuilt)
 ############################################################
-set(LIBUSB_ROOT C:/libusb-1.0.20)
+set(LIBUSB_ROOT C:/local/libusb-1.0.20)
 set(LIBUSB_INCLUDE_DIR ${LIBUSB_ROOT}/include/libusb-1.0)
 set(LIBUSB_LIBRARIES ${LIBUSB_ROOT}/MS64/dll/libusb-1.0.lib)
 
@@ -138,7 +142,7 @@ install(FILES "${LIBUSB_ROOT}/MS64/dll/libusb-1.0.dll" DESTINATION bin)
 ############################################################
 ## SWIG dependency (prebuilt)
 ############################################################
-set(SWIG_ROOT C:/swigwin-3.0.7)
+set(SWIG_ROOT C:/local/swigwin-3.0.8)
 set(SWIG_EXECUTABLE ${SWIG_ROOT}/swig.exe)
 set(SWIG_DIR ${SWIG_ROOT}/Lib)
 
@@ -147,7 +151,7 @@ message(STATUS "SWIG_ROOT: ${SWIG_ROOT}")
 ############################################################
 ## FFTW (prebuilt)
 ############################################################
-set(FFTW3F_ROOT C:/fftw-3.3.4-dll64)
+set(FFTW3F_ROOT C:/local/fftw-3.3.4-dll64)
 set(FFTW3F_INCLUDE_DIRS ${FFTW3F_ROOT})
 set(FFTW3F_LIBRARIES ${FFTW3F_ROOT}/libfftw3f-3.lib)
 

--- a/README.build
+++ b/README.build
@@ -23,8 +23,9 @@ pip install Cheetah
 https://git-scm.com/download/win
 https://cmake.org/files/v3.4/cmake-3.4.1-win32-x86.exe
 
-7. Install doxygen
+7. Install doxygen & LaTex (Miktex)
 http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
+http://mirrors.ctan.org/systems/win32/miktex/setup/basic-miktex-2.9.5823.exe
 
 8. Compile PothosSDR
 set PATH=c:\Python34;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"

--- a/README.build
+++ b/README.build
@@ -5,7 +5,7 @@ Compilation Instructions of GNURadio and PothosSDR using Visual Studio 2015 Comm
 https://www.visualstudio.com/de-de/products/visual-studio-community-vs.aspx
 Select Custom Install, then check C++ under Development Tools
 
-2. Download and install Python 2.7 to C:\python27 and Python 3.4 to C:\python34
+2. Download and install Python 2.7 to C:\Python27 and Python 3.4 to C:\Python34
 https://www.python.org/downloads/
 
 3. Download and install QT 5.6.0
@@ -14,23 +14,20 @@ http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windo
 4. Extract prebuilt.zip package (boost,portaudio,etc.) to C:\local
 
 5. Preinstall python modules needed
-set PATH=%PATH%;c:\python27
+set PATH=%PATH%;c:\Python27;c:\Python27\Scripts
 python Scripts\GNURadioHelper.py
+pip install mako
+pip install Cheetah
 
 6. Install Git for Windows and CMake for Windows
 https://git-scm.com/download/win
 https://cmake.org/files/v3.4/cmake-3.4.1-win32-x86.exe
 
-7. Install Mako and Cheetah python libraries
-set PATH=%PATH$;c:\python27\Scripts
-pip install mako
-pip install Cheetah
-
-8. Install doxygen
+7. Install doxygen
 http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
 
-9. Compile PothosSDR
-set PATH=%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
+8. Compile PothosSDR
+set PATH=c:\Python34;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
 mkdir build
 cd build
 cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:/PothosSDR -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/README.build
+++ b/README.build
@@ -26,7 +26,10 @@ set PATH=%PATH$;c:\python27\Scripts
 pip install mako
 pip install Cheetah
 
-8. Compile PothosSDR
+8. Install doxygen
+http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
+
+9. Compile PothosSDR
 set PATH=%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin"
 mkdir build
 cd build

--- a/README.build
+++ b/README.build
@@ -1,11 +1,11 @@
-Compilation Instructions of GNURadio and PothosSDR using Visual Studio 2015 Community Edition
+Compilation instructions of GNURadio 3.7.8.1 and PothosSDR using Visual Studio 2015 Community Edition
 -------------------------------------
 
 1. Download and install VS2015 Community Edition
 https://www.visualstudio.com/de-de/products/visual-studio-community-vs.aspx
 Select Custom Install, then check C++ under Development Tools
 
-2. Download and install Python 2.7 to C:\Python27 and Python 3.4 to C:\Python34
+2. Download and install Python 2.7 64-Bit to C:\Python27 and Python 3.4 64-Bit to C:\Python34
 https://www.python.org/downloads/
 
 3. Download and install QT 5.6.0
@@ -18,17 +18,23 @@ set PATH=%PATH%;c:\Python27;c:\Python27\Scripts
 python Scripts\GNURadioHelper.py
 pip install mako
 pip install Cheetah
+set PATH=c:\Python34;c:\Python34\Scripts;%PATH%
+pip install mako
 
 6. Install Git for Windows and CMake for Windows
 https://git-scm.com/download/win
 https://cmake.org/files/v3.4/cmake-3.4.1-win32-x86.exe
 
-7. Install doxygen & LaTex (Miktex)
+7. Install doxygen & LaTex (Miktex) & Ghostscript
 http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
 http://mirrors.ctan.org/systems/win32/miktex/setup/basic-miktex-2.9.5823.exe
+http://downloads.ghostscript.com/public/gs918w32.exe
 
 8. Compile PothosSDR
-set PATH=c:\Python27;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
+set PATH=c:\Python34;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin";"c:\Program Files (x86)\gs\gs9.18\bin"
 mkdir build
 cd build
 cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:/PothosSDR -DCMAKE_BUILD_TYPE=RelWithDebInfo
+rebuild_all.bat
+
+9. Set PYTHONPATH to "C:\PothosSDR\lib\site-packages\" and add "C:\Python27;C:\Python27\Scripts" to the PATH variable.

--- a/README.build
+++ b/README.build
@@ -28,7 +28,7 @@ http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
 http://mirrors.ctan.org/systems/win32/miktex/setup/basic-miktex-2.9.5823.exe
 
 8. Compile PothosSDR
-set PATH=c:\Python34;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
+set PATH=c:\Python27;%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
 mkdir build
 cd build
 cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:/PothosSDR -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/README.build
+++ b/README.build
@@ -1,0 +1,33 @@
+Compilation Instructions of GNURadio and PothosSDR using Visual Studio 2015 Community Edition
+-------------------------------------
+
+1. Download and install VS2015 Community Edition
+https://www.visualstudio.com/de-de/products/visual-studio-community-vs.aspx
+Select Custom Install, then check C++ under Development Tools
+
+2. Download and install Python 2.7 to C:\python27 and Python 3.4 to C:\python34
+https://www.python.org/downloads/
+
+3. Download and install QT 5.6.0
+http://download.qt.io/development_releases/qt/5.6/5.6.0-beta/qt-opensource-windows-x86-msvc2015_64-5.6.0-beta.exe
+
+4. Extract prebuilt.zip package (boost,portaudio,etc.) to C:\local
+
+5. Preinstall python modules needed
+set PATH=%PATH%;c:\python27
+python Scripts\GNURadioHelper.py
+
+6. Install Git for Windows and CMake for Windows
+https://git-scm.com/download/win
+https://cmake.org/files/v3.4/cmake-3.4.1-win32-x86.exe
+
+7. Install Mako and Cheetah python libraries
+set PATH=%PATH$;c:\python27\Scripts
+pip install mako
+pip install Cheetah
+
+8. Compile PothosSDR
+set PATH=%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin"
+mkdir build
+cd build
+cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:/PothosSDR -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/README.build
+++ b/README.build
@@ -30,7 +30,7 @@ pip install Cheetah
 http://ftp.stack.nl/pub/users/dimitri/doxygen-1.8.11-setup.exe
 
 9. Compile PothosSDR
-set PATH=%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin"
+set PATH=%PATH%;"c:\Program Files\Git\bin";"C:\Program Files (x86)\CMake\bin";"C:\Program Files\doxygen\bin"
 mkdir build
 cd build
 cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX=C:/PothosSDR -DCMAKE_BUILD_TYPE=RelWithDebInfo

--- a/README.md
+++ b/README.md
@@ -55,3 +55,5 @@ cmake ../ -G "Visual Studio 11 2012 Win64" ^
     -DCMAKE_BUILD_TYPE=RelWithDebInfo
 rebuild_all.bat
 ```
+
+For full compilation instructions, see README.build.

--- a/patches/bladerf_msvc14_fix.diff
+++ b/patches/bladerf_msvc14_fix.diff
@@ -1,0 +1,19 @@
+diff --git a/host/common/include/host_config.h.in b/host/common/include/host_config.h.in
+index 7c6ca5d..0ef97dd 100644
+--- a/host/common/include/host_config.h.in
++++ b/host/common/include/host_config.h.in
+@@ -162,8 +162,12 @@
+ #if _MSC_VER
+ #   define strtok_r    strtok_s
+ #   define strtoull    _strtoui64
+-#   define snprintf    _snprintf
+-#   define vsnprintf   _vsnprintf
++#if _MSC_VER < 1900
++	#   define snprintf    _snprintf
++	#   define vsnprintf   _vsnprintf
++#else
++	#	define STDC99
++#endif
+ #   define strcasecmp  _stricmp
+ #   define strncasecmp _strnicmp
+ #   define fileno      _fileno

--- a/patches/bladerf_msvc14_fix.diff
+++ b/patches/bladerf_msvc14_fix.diff
@@ -1,18 +1,16 @@
 diff --git a/host/common/include/host_config.h.in b/host/common/include/host_config.h.in
-index 7c6ca5d..0ef97dd 100644
+index 7c6ca5d..bdd2850 100644
 --- a/host/common/include/host_config.h.in
 +++ b/host/common/include/host_config.h.in
 @@ -162,8 +162,12 @@
  #if _MSC_VER
  #   define strtok_r    strtok_s
  #   define strtoull    _strtoui64
--#   define snprintf    _snprintf
--#   define vsnprintf   _vsnprintf
 +#if _MSC_VER < 1900
-+	#   define snprintf    _snprintf
-+	#   define vsnprintf   _vsnprintf
+ #   define snprintf    _snprintf
+ #   define vsnprintf   _vsnprintf
 +#else
-+	#	define STDC99
++#define STDC99
 +#endif
  #   define strcasecmp  _stricmp
  #   define strncasecmp _strnicmp

--- a/patches/gnuradio_fix_msvc14.diff
+++ b/patches/gnuradio_fix_msvc14.diff
@@ -1,0 +1,50 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cdf4a6d..b55489a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -120,6 +120,9 @@ IF(MSVC)
+     ELSE(MSVC12) #Visual Studio 12
+         SET(cmake_c_compiler_version "Microsoft Visual Studio 12.0")
+         SET(cmake_cxx_compiler_version "Microsoft Visual Studio 12.0")
++    ELSE(MSVC14) #Visual Studio 14
++        SET(cmake_c_compiler_version "Microsoft Visual Studio 14.0")
++        SET(cmake_cxx_compiler_version "Microsoft Visual Studio 14.0")
+     ENDIF()
+ ELSE()
+     execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+diff --git a/gr-blocks/lib/peak_detector2_fb_impl.cc b/gr-blocks/lib/peak_detector2_fb_impl.cc
+index dc13e66..74cf3d3 100644
+--- a/gr-blocks/lib/peak_detector2_fb_impl.cc
++++ b/gr-blocks/lib/peak_detector2_fb_impl.cc
+@@ -109,7 +109,7 @@ namespace gr {
+             sigout[i]=d_avg;
+           if(iptr[i] > d_avg * (1.0f + d_threshold_factor_rise)) {
+             d_found = true;
+-            d_peak_val = -(float)INFINITY;
++            d_peak_val = -(float)std::numeric_limits<float>::max();
+             set_output_multiple(d_look_ahead);
+             return i;
+           }
+diff --git a/gr-blocks/lib/peak_detector_XX_impl.cc.t b/gr-blocks/lib/peak_detector_XX_impl.cc.t
+index 6846a02..33bfe62 100644
+--- a/gr-blocks/lib/peak_detector_XX_impl.cc.t
++++ b/gr-blocks/lib/peak_detector_XX_impl.cc.t
+@@ -70,7 +70,7 @@ namespace gr {
+ 
+       memset(optr, 0, noutput_items*sizeof(char));
+ 
+-      @I_TYPE@ peak_val = -(@I_TYPE@)INFINITY;
++      @I_TYPE@ peak_val = -(@I_TYPE@)std::numeric_limits<@I_TYPE@>::max();
+       int peak_ind = 0;
+       unsigned char state = 0;
+       int i = 0;
+@@ -101,7 +101,7 @@ namespace gr {
+           else {
+             optr[peak_ind] = 1;
+             state = 0;
+-            peak_val = -(@I_TYPE@)INFINITY;
++            peak_val = -(@I_TYPE@)std::numeric_limits<@I_TYPE@>::max();
+             //printf("Leaving  State 1: Peak: %f  Peak Ind: %d   i: %d  noutput_items: %d\n",
+             //peak_val, peak_ind, i, noutput_items);
+           }
+

--- a/patches/spuce_fix_msvc14.diff
+++ b/patches/spuce_fix_msvc14.diff
@@ -1,0 +1,14 @@
+diff --git a/spuce/typedefs.h b/spuce/typedefs.h
+index 495c00e..a91d3fd 100644
+--- a/spuce/typedefs.h
++++ b/spuce/typedefs.h
+@@ -1,6 +1,7 @@
+ #pragma once
+ // Copyright (c) 2015 Tony Kirke.  Boost Software License - Version 1.0  (http://www.opensource.org/licenses/BSL-1.0)
+ #define _USE_MATH_DEFINES
++#include <math.h>
+ // Putting std::complex here allows possible replacement with custom complex type later
+ #include <complex>
+ #include "complex_operators.h"
+ 
+ 

--- a/patches/spuce_vc11_fixes.diff
+++ b/patches/spuce_vc11_fixes.diff
@@ -79,3 +79,4 @@ index 2530874..aa0211e 100644
  namespace spuce {
  
  inline std::complex<float_type> expj(float_type x) { return (std::complex<float_type>(std::cos(x), std::sin(x))); }
+ 

--- a/patches/volk_fix_msvc14.diff
+++ b/patches/volk_fix_msvc14.diff
@@ -1,0 +1,13 @@
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index a42fcb9..ed29f58 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -345,6 +345,8 @@ if(MSVC)
+         set(cmake_c_compiler_version "Microsoft Visual Studio 11.0")
+     elseif(MSVC12) #Visual Studio 12
+         SET(cmake_c_compiler_version "Microsoft Visual Studio 12.0")
++	elseif(MSVC14) #Visual Studio 14
++        SET(cmake_c_compiler_version "Microsoft Visual Studio 14.0") 
+     endif()
+ else()
+     execute_process(COMMAND ${CMAKE_C_COMPILER} --version


### PR DESCRIPTION
- Visual Studio 2015 Community Edition support added
- Added prebuilt libraries including boost 1.59 compiled for VS2015 64-Bit
- Qt 5.6.0 with VS2015 64-Bit support added
- Changed path for all prebuilt libraries to begin with C:\local
- Added complete instructions for building GnuRadio 3.7.8.1 and PothosSDR using VS2015 CE and Qt 5.6.0
  under Windows 10
